### PR TITLE
Fixed bug when trying to send '}'(0x7D)

### DIFF
--- a/CLX000CanBus.cpp
+++ b/CLX000CanBus.cpp
@@ -203,7 +203,7 @@ bool CLX000CanBus::packFrame(QCanBusFrame const& frame, QByteArray &packedFrame)
     /* Escape any 0x7E sequences */
     packedFrame.append(0x07E);
     for (char const& byteValue: payloadArray) {
-        if( byteValue == 0x7E ) {
+        if( byteValue == 0x7E || byteValue == 0x7D) {
             packedFrame.append(static_cast<quint8>(0x7D));
             packedFrame.append(static_cast<quint8>(byteValue ^ 0b00100000) );
         } else {


### PR DESCRIPTION
When attempting to send the character '}' (0x7D), the packet was not transmitted via CL devices because 0x7D was being interpreted as an escape character. To resolve this, a condition was added to appropriately identify and escape the relevant data. With this adjustment, CAN packets are now successfully transmitted, including those containing 0x7D.